### PR TITLE
Adding subclass command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,27 @@ Timber::render("/views/pages/page-about.twig", $context);
 
 This will find a .php template called `page-about-us.php` in the root theme directory and delete it, as well as the corresponding twig template in `/views/pages/`.
 
+###Create Subclasses
+
+Create a subclass of a built-in Timber class (TimberPost, TimberTerm etc.) in the lib directory by running `wp-timber -s <class> <name>`, where class refers to the class to extend and name is the name assigned to the new subclass.  Site, term, post, menu, menuitem, and user are all accepted as arguments for the base class.
+
+**Output**
+
+`wp-timber -s post TestPost`
+
+Creates TestPost.php in the `/lib` directory, with the following boilerplate:
+```php
+<?php
+
+Class TestPost extends TimberPost { 
+  // Add methods and properties here 
+} 
+
+?>
+```
+
+This will find a .php template called `page-about-us.php` in the root theme directory and delete it, as well as the corresponding twig template in `/views/pages/`.
+
 ###Build from a Config file
 With Timber CLI you can generate a series of templates with queries from a configuration file. Create a `.timber` file that contains JSON to generate as many templates with queries as you want.
 

--- a/src/build.js
+++ b/src/build.js
@@ -6,6 +6,7 @@ import mkdirp from 'mkdirp';
 
 import createTemplates from './createTemplates.js'
 import createQuery from './createQuery.js';
+import createSubclass from './createSubclass.js';
 
 const buildTemplatesFromConfig = function(){
   fs.readFile('./.timber', 'utf8', function(err, res){

--- a/src/createSubclass.js
+++ b/src/createSubclass.js
@@ -1,0 +1,35 @@
+import fs from 'fs';
+import mkdirp from 'mkdirp';
+
+const createSubclass = args => {
+  const type = args[0];
+  const name = args[1];
+  
+  fs.writeFileSync('./lib/' + name + '.php', buildPHPTemplate(type, name));
+
+  console.log('Subclass Created!');
+}
+
+function buildPHPTemplate(type, name){
+  var baseClass = selectClass(type);
+
+  return '<?php \n' +
+  '\n' +
+  'Class ' + name + ' extends ' + baseClass + '{ \n' +
+  '// Add methods and properties here \n' +
+  '} \n'
+  '?>'
+}
+
+function selectClass(type) {
+  var classes = {
+    'post'      : 'TimberPost',
+    'term'      : 'TimberTerm',
+    'menu'      : 'TimberMenu',
+    'menuitem'  : 'TimberMenuItem',
+    'user'      : 'TimberUser'
+  }
+  return classes.type;
+}
+
+export default createSubclass;

--- a/src/createSubclass.js
+++ b/src/createSubclass.js
@@ -4,10 +4,15 @@ import mkdirp from 'mkdirp';
 const createSubclass = args => {
   const type = args[0];
   const name = args[1];
-  
-  fs.writeFileSync('./lib/' + name + '.php', buildPHPTemplate(type, name));
 
-  console.log('Subclass Created!');
+  if (selectClass(type)) {
+    mkdirp.sync( './lib');
+    fs.writeFileSync('./lib/' + name + '.php', buildPHPTemplate(type, name));
+    console.log('Subclass Created!');
+  } else {
+    console.log('Please use a valid base class (post, term, menu, menuitem, user)');
+  }
+
 }
 
 function buildPHPTemplate(type, name){
@@ -15,21 +20,26 @@ function buildPHPTemplate(type, name){
 
   return '<?php \n' +
   '\n' +
-  'Class ' + name + ' extends ' + baseClass + '{ \n' +
-  '// Add methods and properties here \n' +
+  'Class ' + name + ' extends ' + baseClass + ' { \n' +
+  '\t// Add methods and properties here \n' +
   '} \n'
   '?>'
 }
 
-function selectClass(type) {
+function selectClass(type){
   var classes = {
-    'post'      : 'TimberPost',
-    'term'      : 'TimberTerm',
-    'menu'      : 'TimberMenu',
-    'menuitem'  : 'TimberMenuItem',
-    'user'      : 'TimberUser'
+    site      : 'TimberSite',
+    post      : 'TimberPost',
+    term      : 'TimberTerm',
+    menu      : 'TimberMenu',
+    menuitem  : 'TimberMenuItem',
+    user      : 'TimberUser'
   }
-  return classes.type;
+  if (classes[type]) {
+    return classes[type];
+  } else { 
+    return false;
+  }
 }
 
 export default createSubclass;

--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,9 @@ import mkdirp from 'mkdirp';
 import createTemplates from './createTemplates.js'
 import deleteTemplates from './removeTemplates.js';
 import createQuery from './createQuery.js';
+import createSubclass from './createSubclass.js';
 import buildTemplatesFromConfig from './build.js';
-import creaeSubclass from './createSubclass.js';
+
 
 cli.parse({
     create:   ['c', 'Create A Template'],
@@ -26,7 +27,7 @@ cli.main(function(args, options){
   console.log('options: ', options);
 
 
-  const { create, remove, query, help, init } = options;
+  const { create, remove, query, help, init, subclass } = options;
 
   if (args[0] == 'build'){
     buildTemplatesFromConfig()

--- a/src/index.js
+++ b/src/index.js
@@ -8,12 +8,14 @@ import mkdirp from 'mkdirp';
 import createTemplates from './createTemplates.js'
 import deleteTemplates from './removeTemplates.js';
 import createQuery from './createQuery.js';
-import buildTemplatesFromConfig from './build.js'
+import buildTemplatesFromConfig from './build.js';
+import creaeSubclass from './createSubclass.js';
 
 cli.parse({
     create:   ['c', 'Create A Template'],
     remove:   ['r', 'Remove A Template'],
     query:   ['q', 'Add Query to Template'],
+    subclass: ['s', 'Add An Object Subclass'],
     help:   ['h', 'HALP']
 });
 
@@ -47,6 +49,10 @@ cli.main(function(args, options){
 
     if (init){
       init();
+    }
+
+    if (subclass) {
+      createSubclass(args);
     }
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var rimraf = require('rimraf');
 var createTemplates = require('../lib/createTemplates.js');
 var deleteTemplates = require('../lib/removeTemplates.js');
+var createSubclass = require('../lib/createSubclass.js');
 
 function cleanUp(){
   rimraf.sync('./views');
@@ -11,11 +12,13 @@ function cleanUp(){
 describe('createTemplates', function() {
   it ('should create a PHP and Twig template', function(done){
 
+    console.log(createTemplates);
+
     var args = ['page', 'test'];
     var type = args[0];
     var name = args[1];
 
-    createTemplates(args);
+    createTemplates.default(args);
 
     if (fs.existsSync('./' + type + '-' + name + '.php')){
       console.log('php template exists');
@@ -29,6 +32,26 @@ describe('createTemplates', function() {
     } else {
       cleanUp();
       throw new Error('PHP template not created')
+    }
+  });
+});
+
+describe('createSubclass', function() {
+  it ('should create a subclass of TimberPost', function(done){
+
+    var args = ['post', 'TestPost'];
+    var type = args[0];
+    var name = args[1];
+
+    createSubclass.default(args);
+
+    if (fs.existsSync('./lib/' + name + '.php')){
+      console.log('subclass exists');
+      cleanUp();
+      return done();
+    } else {
+      cleanUp();
+      throw new Error('Subclass not created')
     }
   });
 });


### PR DESCRIPTION
This adds a command to create subclasses of Timber objects, like @jarednova references in #1 .  Syntax for the new command is `wp-timber -s <baseclass> <newclass>`.  So for example, `wp-timber term NewTerm` would create a new php file in the lib directory with boilerplate code for a NewTerm class extending TimberTerm.

Another quick note -- I edited  line 18 in test.js to read `createTemplates.default(args);` rather than `createTemplates(args)`.  This seemed to be the only way I get the tests to run, but I'm happy to roll it back if it's an issue, it very well could be an error on my part.
